### PR TITLE
Fixed homewareMQTT.py control publish issue

### DIFF
--- a/homewareMQTT.py
+++ b/homewareMQTT.py
@@ -56,11 +56,11 @@ def control(payload):
     # Analyze the message
     if intent == 'execute':
         hData.updateParamStatus(id,param,value)
-        publish.single("device/"+id, hData.getStatus()[id], hostname="localhost")
+        publish.single("device/"+id, json.dumps(hData.getStatus()[id]), hostname="localhost")
     elif intent == 'rules':
         hData.updateParamStatus(id,param,value)
     elif intent == 'request':
-        publish.single("device/"+id, hData.getStatus()[id], hostname="localhost")
+        publish.single("device/"+id, json.dumps(hData.getStatus()[id]), hostname="localhost")
 
 
 


### PR DESCRIPTION
The topic for controlling devices did not work.
Publishing an execute or request intent to device/control as shown in the [Wiki](https://github.com/kikeelectronico/Homeware-LAN/wiki/Communicate-a-hardware-device-with-Homeware-LAN#hardware-to-homeware---send-data) did not publish the updated value to device/<device-id> topic.